### PR TITLE
Remove functionality to render plain HTML

### DIFF
--- a/sandbox/experiment/smartserve.js
+++ b/sandbox/experiment/smartserve.js
@@ -1,6 +1,10 @@
 import * as experience1 from './experience'
 import * as experience2 from './experience2'
 
+import driftwood from 'driftwood'
+
+driftwood.enable({'*': '*'}, {persist: true})
+
 evaluateExperience('exp1', experience1)
 evaluateExperience('exp2', experience2)
 

--- a/wrapper/QubitReactWrapper.js
+++ b/wrapper/QubitReactWrapper.js
@@ -58,10 +58,8 @@ var QubitReactWrapper = React.createClass({
   renderWithOverride: function () {
     var renderFunction = this.getNamespace().renderFunction
     var result = renderFunction(this.props, React)
-    if (typeof result === 'string') {
-      return React.createElement('div', {
-        dangerouslySetInnerHTML: { __html: result }
-      })
+    if (!React.isValidElement(result)) {
+      throw new Error('Render function did not return a valid React element')
     } else {
       return result
     }

--- a/wrapper/__tests__/QubitReactWrapper-test.js
+++ b/wrapper/__tests__/QubitReactWrapper-test.js
@@ -53,7 +53,7 @@ describe('when there is a handler', () => {
       react: {
         components: {
           fooWrapper: {
-            handler: handler
+            renderFunction: handler
           }
         }
       }
@@ -85,7 +85,37 @@ describe('when the handler throws an error', () => {
       react: {
         components: {
           fooWrapper: {
-            handler: handler
+            renderFunction: handler
+          }
+        }
+      }
+    }
+    component = shallow(
+      <QubitReactWrapper id='fooWrapper'>
+        <h2 className='foo'>Foo</h2>
+      </QubitReactWrapper>
+    )
+  })
+  afterEach(() => {
+    window.__qubit = undefined
+  })
+  it('renders the children', () => {
+    expect(component.find('.foo').length).toBe(1)
+  })
+})
+
+describe('when the handler does not return a React element', () => {
+  let handler
+  let component
+  beforeEach(() => {
+    handler = jest.fn((props, React) => {
+      return 'bad thing'
+    })
+    window.__qubit = {
+      react: {
+        components: {
+          fooWrapper: {
+            renderFunction: handler
           }
         }
       }


### PR DESCRIPTION
Since we'll have JSX no longer need this to make code look cleaner

Can no longer do:
```js
slots.render('header', () => { return '<div></div>' })
```
@oliverwoodings @KidkArolis 