### PR TITLE
Support server side rendering

### DIFF
--- a/wrapper/index.js
+++ b/wrapper/index.js
@@ -1,1 +1,9 @@
-module.exports = require('./QubitReactWrapper')
+if (typeof window !== 'undefined') {
+  module.exports = require('./QubitReactWrapper')
+} else {
+  // If server side rendering, there will be nothing in the global namespace
+  // to override. So we just render the children
+  module.exports = function (props) {
+    return props.children
+  }
+}


### PR DESCRIPTION
When rendering server side there is no window. But because there will never be an override when rendering server side, we can just export a simple component that renders the children

@oliverwoodings @ThatTobMate