### PR TITLE
Fix version check when wrapper hasnt loaded

### DIFF
--- a/experience/__tests__/validateVersions-test.js
+++ b/experience/__tests__/validateVersions-test.js
@@ -13,4 +13,7 @@ describe('validateVersions', () => {
   it('returns true for mismatched patch versions', () => {
     expect(validateVersions('1.0.0', '1.0.1')).toBe(true)
   })
+  it('returns true when wrapper version is undefined', () => {
+    expect(validateVersions('1.0.0', undefined)).toBe(true)
+  })
 })

--- a/experience/validateVersions.js
+++ b/experience/validateVersions.js
@@ -3,6 +3,12 @@ var semver = require('../lib/semver')
 
 module.exports = function validateVersions (experienceVersion, wrapperVersion) {
   log.debug('Checking wrapper version: "' + wrapperVersion + '"')
+
+  if (typeof wrapperVersion === 'undefined') {
+    log.warn('Cannot find wrapper version')
+    return true
+  }
+
   if (!semver.isValid(wrapperVersion)) {
     log.error('Invalid wrapper version')
     return false


### PR DESCRIPTION
If experiences loads too fast or the page doesnt have a wrapper this will throw because there is no version exposed by the wrapper. In this case we can just ignore the check