### PR TITLE
Use componentDidMount instead of componentWillMount

### DIFF
--- a/wrapper/QubitReactWrapper.js
+++ b/wrapper/QubitReactWrapper.js
@@ -20,7 +20,7 @@ var QubitReactWrapper = createReactClass({
     return getComponent(this.props.id)
   },
 
-  componentWillMount: function () {
+  componentDidMount: function () {
     bootstrapWrapper(this.props.id)
     var ns = this.getNamespace()
     ns.instances = ns.instances || []


### PR DESCRIPTION
`componentWillMount` gets called when server-side rendering, which means we end up registering the handler on the fake window object, however `componentWillUnmount` does _not_ get called server-side, causing a memory leak (we never clean up unmounted instances).

Switching to `componentDidMount` is a simple fix.