### PR TITLE
Implement new, simpler API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ module.exports = function experienceExecution (options) {
 
 ```js
 module.exports = function experienceActivation (options, cb) {
-  var saleEnds = Date.UTC(2017, 0, 1, 0, 0, 0)
-  var remaining = saleEnds - Date.now()
+  const saleEnds = Date.UTC(2017, 0, 1, 0, 0, 0)
+  const remaining = saleEnds - Date.now()
   if (remaining > (60 * 60 * 1000)) return
   if (remaining < 0) return
 
@@ -120,8 +120,8 @@ module.exports = function experienceActivation (options, cb) {
 
 ```js
 module.exports = function experienceExecution (options) {
-  var saleEnds = options.state.get('saleEnds')
-  var React = options.react.getReact()
+  const saleEnds = options.state.get('saleEnds')
+  const React = options.react.getReact()
 
   class Countdown extends React.Component {
     componentWillMount () {
@@ -222,7 +222,7 @@ At the beginning of January 2020, we deprecated the old callback-based wrapper r
 1. The old API was overly-verbose and complex
 2. Under certain scenarios, wrapper ownership would be claimed when an experience wasn't actually going to fire, preventing all other experiences from claiming that wrapper.
 
-While both syntaxes are currently available, we will be removing support for the old callback-based registration in the future in version 2.0 of the `qubit-react/experience` package. Here is an example of how to upgrade to the new syntax:
+While both APIs are currently available, we will be removing support for the old callback-based registration in the future in version 2.0 of the `qubit-react/experience` package. Here is an example of how to upgrade to the new format:
 
 **Old**
 ```js

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ To expose a component for use in Experiences, wrap the relevant components with 
 ```js
 import QubitReact from 'qubit-react/wrapper'
 
-<QubitReact id='header' ...props>
-  <Header ...props />
+<QubitReact id='header' {...props}>
+  <Header {...props} />
 </QubitReact>
 
 ```
@@ -23,61 +23,23 @@ A unique `id` is required for each wrapped component. It is recommended that all
 ## Usage
 _This section refers to the code that you write inside Qubit's platform._
 
-In Qubit Experiences use `qubit-react/experience` to interact with the wrapper.
+In Qubit Experiences you can interact interact with the wrapper using the `options.react` interface.
 
 ### Activation
 
-#### Setup
-
-First initiate the library by passing in the experience meta information.
-
-```js
-function experienceActivation (options, cb) {
-  var experience = require('qubit-react/experience')(options.meta)
-}
-```
-
-#### Claiming Wrapper Ownership
+#### Registering for Wrapper Ownership
 
 Qubit React has a concept of wrapper ownership. This means that only a single experience can control the contents of a wrapper at any given time. This reduces conflicts between experiences attempting to modify the same component.
 
-In order to take ownership of a wrapper during the experience activation phase, use the `experience.register` function. You can claim multiple wrappers by passing in multiple wrapper IDs to register.
+Ownership will not be taken until the `options.react.render()` method is called in the experience execution function. It is your job to ensure that multiple experiences do not try to execute at the same time. If they do, only the first experience will execute succesfully; all subsequent attempts will result in an error being thrown.
+
+In order to take ownership of a wrapper during the experience activation phase, use the `options.react.register()` method. You can claim multiple wrappers by passing in multiple wrapper IDs to register. This will return a promise that resolves once React is available and the wrapper is ready to render on the page.
 
 ```js
 function experienceActivation (options, cb) {
-  var experience = require('qubit-react/experience')(options.meta)
-
-  experience.register(['header'], function (slots, React) {
-    // If we get here, it means we have successfully claimed the wrapper
-  })
+  options.react.register(['header']).then(cb)
 }
 ```
-
-#### Releasing Wrapper Ownership
-
-```js
-function experienceActivation (options, cb) {
-  var experience = require('qubit-react/experience')(options.meta)
-
-  var release = experience.register(['header'], function (slots, React) {    
-    // use state to pass the slots and React to execution
-    options.state.set('slots', slots)
-    options.state.set('React', React)
-    cb()
-  })
-
-  return {
-    remove: function () {
-      // important to release the ownership of the wrappers
-      // so that other experiences on other virtual pageviews
-      // can claim them.
-      release()
-    }
-  }
-}
-```
-
-Calling `release` will render the original content of the wrapped component and release the ownership so that other experiences can claim it.
 
 ### Execution
 
@@ -87,8 +49,7 @@ Now that we are finally in execution phase, let's render some custom content int
 
 ```js
 function experienceExecution (options) {
-  var React = options.state.get('React')
-  var slots = options.state.get('slots')
+  const React = options.react.getReact()
 
   class NewHeader extends React.Component {
     render () {
@@ -96,15 +57,9 @@ function experienceExecution (options) {
     }
   }
 
-  slots.render('header', function (props) {
+  options.react.render('header', function (props) {
     return <NewHeader />
   })
-  
-  return {
-    remove: function () {
-      slots.release()
-    }
-  }
 }
 ```
 
@@ -114,33 +69,36 @@ Sometimes, it might be useful to render the original content temporarily. For ex
 
 ```js
 function experienceExecution (options) {
-  var React = options.state.get('React')
-  var slots = options.state.get('slots')
-  
-  // ...
+  const React = options.react.getReact()
 
   setTimeout(() => {
     // renders original content
-    slots.render('header', function (props) {
+    options.react.render('header', function (props) {
       return props.children
     })
     setTimeout(() => {
       // renders new content again
-      slots.render('header', function (props) {
+      options.react.render('header', function (props) {
         return <NewContent />
       })
     }, 5000)
   }, 5000)
-  
-  return {
-    remove: function () {
-      slots.release()
-    }
-  }
 }
 ```
 
-It's different from calling `slots.release()`, because release is final and the wrapper can't be used again in this experience. It's really meant for cleanup between virtual page views.
+### Manually releasing ownership
+
+Qubit Experiences will automatically take care of releasing wrapper ownership when experiences restart due to virtual page views. If for some reason you need to release ownership under other circumstances, there is a method available to do so:
+
+```js
+function experienceExecution (options) {
+  options.react.render('header', () => <NewContent />)
+
+  setTimeout(() => {
+    options.react.release()
+  }, 5000)
+}
+```
 
 ### Real World Example
 
@@ -148,26 +106,13 @@ It's different from calling `slots.release()`, because release is final and the 
 
 ```js
 function experienceActivation (options, cb) {
-  var experience = require('qubit-react/experience')(options.meta)
-
   var saleEnds = Date.UTC(2017, 0, 1, 0, 0, 0)
   var remaining = saleEnds - Date.now()
   if (remaining > (60 * 60 * 1000)) return
   if (remaining < 0) return
 
-  var release = experience.register([
-    'header-subtitle-text',
-    'promo-banner-text'
-  ], function (slots, React) {
-    options.state.set('saleEnds', saleEnds)
-    options.state.set('slots', slots)
-    options.state.set('React', React)
-    cb()
-  })
-
-  return {
-    remove: release
-  }
+  options.state.set('saleEnds', saleEnds)
+  options.react.register(['header-subtitle-text', 'promo-banner-text'], cb)
 }
 ```
 
@@ -176,8 +121,7 @@ function experienceActivation (options, cb) {
 ```js
 function experienceExecution (options) {
   var saleEnds = options.state.get('saleEnds')
-  var React = options.state.get('React')
-  var slots = options.state.get('slots')
+  var React = options.react.getReact()
 
   class Countdown extends React.Component {
     componentWillMount () {
@@ -190,6 +134,7 @@ function experienceExecution (options) {
         this.setState({ remaining: endDate - Date.now() })
         if (remaining < 0) {
           clearInterval(interval)
+          options.react.release()
         }
       }, 1000)
     }
@@ -202,17 +147,13 @@ function experienceExecution (options) {
     }
   }
 
-  slots.render('header-subtitle-text', function (props) {
+  options.react.render('header-subtitle-text', function (props) {
     return <span>Great offers somewhere...</span>
   })
 
-  slots.render('promo-banner-text', function (props) {
+  options.react.render('promo-banner-text', function (props) {
     return <Countdown endDate={saleEnds} />
   })
-
-  return {
-    remove: slots.release
-  }
 }
 
 ```
@@ -235,7 +176,7 @@ This section provides technical details on how the wrapper works.
 
 #### Determining render function
 
-When a wrapper is first mounted, it creates an object under `window.__qubit.react.components[id]`, where the `id` is unique to the wrapper. There are two things on the object we care about:
+When a wrapper is first mounted, it creates an object under `window.__qubit.react.components[id]`, where the `id` is unique to the wrapper. There are three things on the object we care about:
 
 ```js
 {
@@ -257,8 +198,14 @@ window.__qubit.react = window.__qubit.react || {}
 window.__qubit.react.components = window.__qubit.react.components || {}
 window.__qubit.react.components.header = window.__qubit.react.components.header || {}
 
-// Add the handler
+// Add the generic handler to be called by the wrapper
 window.__qubit.react.components.header.renderFunction = function (props, React) {
+  // If an experience handler is available, use that, otherwise return props.children
+}
+
+// Register the specific experience handler
+window.__qubit.react.components.header.owner = '12345' // experience ID
+window.__qubit.react.components.header.ownerRenderFunction = function (props, React) {
   return <h2>New Site Header!</h2>
 }
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ownership will not be taken until the `options.react.render()` method is called 
 In order to take ownership of a wrapper during the experience activation phase, use the `options.react.register()` method. You can claim multiple wrappers by passing in multiple wrapper IDs to register. This will return a promise that resolves once React is available and the wrapper is ready to render on the page.
 
 ```js
-function experienceActivation (options, cb) {
+module.exports = function experienceActivation (options, cb) {
   options.react.register(['header']).then(cb)
 }
 ```
@@ -48,7 +48,7 @@ function experienceActivation (options, cb) {
 Now that we are finally in execution phase, let's render some custom content into our wrapped component.
 
 ```js
-function experienceExecution (options) {
+module.exports = function experienceExecution (options) {
   const React = options.react.getReact()
 
   class NewHeader extends React.Component {
@@ -68,7 +68,7 @@ function experienceExecution (options) {
 Sometimes, it might be useful to render the original content temporarily. For example, if you show the original content, but then want to render something custom again, you could do this:
 
 ```js
-function experienceExecution (options) {
+module.exports = function experienceExecution (options) {
   const React = options.react.getReact()
 
   setTimeout(() => {
@@ -91,7 +91,7 @@ function experienceExecution (options) {
 Qubit Experiences will automatically take care of releasing wrapper ownership when experiences restart due to virtual page views. If for some reason you need to release ownership under other circumstances, there is a method available to do so:
 
 ```js
-function experienceExecution (options) {
+module.exports = function experienceExecution (options) {
   options.react.render('header', () => <NewContent />)
 
   setTimeout(() => {
@@ -105,7 +105,7 @@ function experienceExecution (options) {
 #### Activation
 
 ```js
-function experienceActivation (options, cb) {
+module.exports = function experienceActivation (options, cb) {
   var saleEnds = Date.UTC(2017, 0, 1, 0, 0, 0)
   var remaining = saleEnds - Date.now()
   if (remaining > (60 * 60 * 1000)) return
@@ -119,7 +119,7 @@ function experienceActivation (options, cb) {
 #### Execution
 
 ```js
-function experienceExecution (options) {
+module.exports = function experienceExecution (options) {
   var saleEnds = options.state.get('saleEnds')
   var React = options.react.getReact()
 

--- a/__tests__/conflict-e2e-test.js
+++ b/__tests__/conflict-e2e-test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme'
 
 import experience from '../experience'
 
-it('e2e', () => {
+it('conflict', async () => {
   const React = require('react')
   const QubitReactWrapper = require('../wrapper')
   mount(
@@ -12,11 +12,14 @@ it('e2e', () => {
   )
 
   // claim a wrapper
-  experience({ owner: 'foo' }).register(['wrapper'], () => {})
+  const instance1 = experience({ owner: 'foo' })
+  await instance1.register(['wrapper'])
 
-  // try claiming the same one
-  const cb = jest.fn()
-  experience({ owner: 'bar' }).register(['wrapper'], cb)
+  const instance2 = experience({ owner: 'bar' })
+  await instance2.register(['wrapper'])
 
-  expect(cb).not.toHaveBeenCalled()
+  instance1.render('wrapper', () => null)
+  expect(() => {
+    instance2.render('wrapper', () => null)
+  }).toThrow(/it is already claimed/)
 })

--- a/__tests__/register-e2e-test.js
+++ b/__tests__/register-e2e-test.js
@@ -2,7 +2,43 @@ import { mount } from 'enzyme'
 
 import experience from '../experience'
 
-it('e2e', () => {
+it('e2e - modern', async () => {
+  let React = require('react')
+  const QubitReactWrapper = require('../wrapper')
+  const mounted = mount(
+    <QubitReactWrapper id='wrapper'>
+      <div className='wrapped' />
+    </QubitReactWrapper>
+  )
+
+  // claim a wrapper
+  const instance = experience({ owner: 'owner123' })
+
+  await instance.register(['wrapper'])
+  React = instance.getReact()
+
+  expect(mounted.find('.wrapped').length).toEqual(1)
+  expect(mounted.find('.replaced').length).toEqual(0)
+
+  instance.render('wrapper', () => { return <div className='replaced' /> })
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(0)
+  expect(mounted.find('.replaced').length).toEqual(1)
+
+  instance.render('wrapper', () => { return <div className='anotherThing' /> })
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(0)
+  expect(mounted.find('.replaced').length).toEqual(0)
+  expect(mounted.find('.anotherThing').length).toEqual(1)
+
+  instance.release()
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(1)
+  expect(mounted.find('.replaced').length).toEqual(0)
+  expect(mounted.find('.anotherThing').length).toEqual(0)
+})
+
+it.skip('e2e - legacy', async () => {
   const React = require('react')
   const QubitReactWrapper = require('../wrapper')
   const mounted = mount(
@@ -12,17 +48,17 @@ it('e2e', () => {
   )
 
   // claim a wrapper
-  experience({ owner: 'owner123' }).register(['wrapper'], async (slots, React) => {
+  await experience({ owner: 'owner123' }).register(['wrapper'], async (slots, React) => {
     expect(mounted.find('.wrapped').length).toEqual(1)
     expect(mounted.find('.replaced').length).toEqual(0)
 
     slots.render('wrapper', () => { return <div className='replaced' /> })
-    await defer()
+    mounted.update()
     expect(mounted.find('.wrapped').length).toEqual(0)
     expect(mounted.find('.replaced').length).toEqual(1)
 
     slots.render('wrapper', () => { return <div className='anotherThing' /> })
-    await defer()
+    mounted.update()
     expect(mounted.find('.wrapped').length).toEqual(0)
     expect(mounted.find('.replaced').length).toEqual(0)
     expect(mounted.find('.anotherThing').length).toEqual(1)
@@ -33,9 +69,3 @@ it('e2e', () => {
     expect(mounted.find('.anotherThing').length).toEqual(0)
   })
 })
-
-function defer () {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 0)
-  })
-}

--- a/__tests__/register-e2e-test.js
+++ b/__tests__/register-e2e-test.js
@@ -38,7 +38,7 @@ it('e2e - modern', async () => {
   expect(mounted.find('.anotherThing').length).toEqual(0)
 })
 
-it.skip('e2e - legacy', async () => {
+it('e2e - legacy', async () => {
   const React = require('react')
   const QubitReactWrapper = require('../wrapper')
   const mounted = mount(
@@ -48,24 +48,27 @@ it.skip('e2e - legacy', async () => {
   )
 
   // claim a wrapper
-  await experience({ owner: 'owner123' }).register(['wrapper'], async (slots, React) => {
-    expect(mounted.find('.wrapped').length).toEqual(1)
-    expect(mounted.find('.replaced').length).toEqual(0)
-
-    slots.render('wrapper', () => { return <div className='replaced' /> })
-    mounted.update()
-    expect(mounted.find('.wrapped').length).toEqual(0)
-    expect(mounted.find('.replaced').length).toEqual(1)
-
-    slots.render('wrapper', () => { return <div className='anotherThing' /> })
-    mounted.update()
-    expect(mounted.find('.wrapped').length).toEqual(0)
-    expect(mounted.find('.replaced').length).toEqual(0)
-    expect(mounted.find('.anotherThing').length).toEqual(1)
-
-    slots.release()
-    expect(mounted.find('.wrapped').length).toEqual(1)
-    expect(mounted.find('.replaced').length).toEqual(0)
-    expect(mounted.find('.anotherThing').length).toEqual(0)
+  const [slots] = await new Promise((resolve) => {
+    experience({ owner: 'owner123' }).register(['wrapper'], (slots, React) => resolve([slots, React]))
   })
+
+  expect(mounted.find('.wrapped').length).toEqual(1)
+  expect(mounted.find('.replaced').length).toEqual(0)
+
+  slots.render('wrapper', () => { return <div className='replaced' /> })
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(0)
+  expect(mounted.find('.replaced').length).toEqual(1)
+
+  slots.render('wrapper', () => { return <div className='anotherThing' /> })
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(0)
+  expect(mounted.find('.replaced').length).toEqual(0)
+  expect(mounted.find('.anotherThing').length).toEqual(1)
+
+  slots.release()
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(1)
+  expect(mounted.find('.replaced').length).toEqual(0)
+  expect(mounted.find('.anotherThing').length).toEqual(0)
 })

--- a/experience/__tests__/onReactReady-test.js
+++ b/experience/__tests__/onReactReady-test.js
@@ -39,8 +39,7 @@ describe('onReactReady', () => {
     it('adds the cb to onReactReady array', () => {
       const cb = jest.fn()
       onReactReady().then(cb)
-      const ns = window.__qubit.react
-      expect(ns.onReactReady[0]())
+      window.__qubit.react.onReactReady[0]()
       expect(cb).toHaveBeenCalled()
     })
   })

--- a/experience/__tests__/onReactReady-test.js
+++ b/experience/__tests__/onReactReady-test.js
@@ -20,12 +20,12 @@ describe('onReactReady', () => {
     })
     it('runs the cb', () => {
       const cb = jest.fn()
-      onReactReady(cb)
+      onReactReady().then(cb)
       expect(cb).toHaveBeenCalled()
     })
     it('calls the cb with React', () => {
       const cb = jest.fn()
-      onReactReady(cb)
+      onReactReady().then(cb)
       expect(cb).toHaveBeenCalledWith(React)
     })
   })
@@ -33,14 +33,15 @@ describe('onReactReady', () => {
   describe('if react is not ready', () => {
     it('does not run the cb', () => {
       const cb = jest.fn()
-      onReactReady(cb)
+      onReactReady().then(cb)
       expect(cb).not.toHaveBeenCalled()
     })
     it('adds the cb to onReactReady array', () => {
       const cb = jest.fn()
-      onReactReady(cb)
+      onReactReady().then(cb)
       const ns = window.__qubit.react
-      expect(ns.onReactReady[0]).toBe(cb)
+      expect(ns.onReactReady[0]())
+      expect(cb).toHaveBeenCalled()
     })
   })
 })

--- a/experience/createRegister.js
+++ b/experience/createRegister.js
@@ -42,10 +42,10 @@ module.exports = function createRegister (owner) {
       var wrapper = wrappers[id]
 
       if (!wrapper) {
-        boom('Slot "' + id + '" not found, did you forget to register it?')
+        boom('Cannot render into slot "' + id + '", it has not been registered')
       }
       if (!wrapper.canClaim()) {
-        boom('Cannot render into slot "' + id + '", it is already claimed')
+        boom('Cannot render into slot "' + id + '", it is already claimed by experience ' + wrapper.getOwner())
       }
       wrapper.render(fn)
     }

--- a/experience/getWrapper.js
+++ b/experience/getWrapper.js
@@ -10,6 +10,9 @@ module.exports = function getWrapper (registrar, id) {
     canClaim: function canClaim () {
       return !ns.owner || ns.owner === registrar
     },
+    getOwner: function getOwner () {
+      return ns.owner
+    },
     register: function register () {
       if (!ns.renderFunction) {
         ns.renderFunction = createRenderFunction(ns)

--- a/experience/getWrapper.js
+++ b/experience/getWrapper.js
@@ -21,7 +21,7 @@ module.exports = function getWrapper (registrar, id) {
     },
     release: function release () {
       if (ns.owner === registrar) {
-        ns.ownerRenderFunction = null
+        ns.ownerRenderFunction = undefined
         update()
         ns.owner = undefined
       }

--- a/experience/index.js
+++ b/experience/index.js
@@ -1,5 +1,6 @@
 var Promise = require('sync-p')
 var createRegister = require('./createRegister')
+var log = require('./createLogger')
 
 module.exports = function (meta) {
   var owner = meta && (meta.owner || meta.experimentId)
@@ -7,6 +8,7 @@ module.exports = function (meta) {
     throw new Error('No owner specified')
   }
 
+  var hasLoggedDeprecation = false
   var register = createRegister(owner)
   var release = null
   var render = null
@@ -36,6 +38,10 @@ module.exports = function (meta) {
       }
 
       if (cb) {
+        if (!hasLoggedDeprecation) {
+          log.warn('You are using the deprecated callback-based registration method in experience ' + owner + '. Go to https://docs.qubit.com to find out how and why to upgrade to the new promise-based approach.')
+          hasLoggedDeprecation = true
+        }
         release = register(ids, cb)
         return release
       } else {

--- a/experience/index.js
+++ b/experience/index.js
@@ -15,13 +15,13 @@ module.exports = function (meta) {
   return {
     getReact: function () {
       if (!React) {
-        throw new Error('React not available, you probably forgot to call `options.react.register()`')
+        throw new Error('React not available, you have either not called `options.react.register()` or have not waited until it has resolved')
       }
       return React
     },
     render: function (id, fn) {
       if (!render) {
-        throw new Error('No slots available to render, you probably forgot to call `options.react.register()`')
+        throw new Error('No slots available to render, you have either not called `options.react.register()` or have not waited until it has resolved')
       }
       render(id, fn)
     },

--- a/experience/index.js
+++ b/experience/index.js
@@ -1,3 +1,4 @@
+var Promise = require('sync-p')
 var createRegister = require('./createRegister')
 
 module.exports = function (meta) {
@@ -5,7 +6,47 @@ module.exports = function (meta) {
   if (!owner) {
     throw new Error('No owner specified')
   }
+
+  var register = createRegister(owner)
+  var release = null
+  var render = null
+  var React = null
+
   return {
-    register: createRegister(owner)
+    getReact: function () {
+      if (!React) {
+        throw new Error('React not available, you probably forgot to call `options.react.register()`')
+      }
+      return React
+    },
+    render: function (id, fn) {
+      if (!render) {
+        throw new Error('No slots available to render, you probably forgot to call `options.react.register()`')
+      }
+      render(id, fn)
+    },
+    release: function () {
+      if (release) {
+        release()
+      }
+    },
+    register: function (ids, cb) {
+      if (release) {
+        throw new Error('Register should only be called once per experience')
+      }
+
+      if (cb) {
+        release = register(ids, cb)
+        return release
+      } else {
+        return new Promise(function (resolve) {
+          release = register(ids, function (slots, _React) {
+            render = slots.render
+            React = _React
+            resolve()
+          })
+        })
+      }
+    }
   }
 }

--- a/experience/onReactReady.js
+++ b/experience/onReactReady.js
@@ -1,15 +1,19 @@
+var Promise = require('sync-p')
+
 var getReact = require('../lib/namespace').getReact
 var log = require('./createLogger')('onReactReady')
 
-module.exports = function onReactReady (cb) {
-  var ns = getReact()
-  if (ns.React) {
-    log.debug('React available, running callback')
-    cb(ns.React)
-    return
-  }
+module.exports = function onReactReady () {
+  return new Promise(function (resolve) {
+    var ns = getReact()
+    if (ns.React) {
+      log.debug('React available, running callback')
+      resolve(ns.React)
+      return
+    }
 
-  log.debug('React unavailable, pushing into onReactReady array')
-  ns.onReactReady = ns.onReactReady || []
-  ns.onReactReady.push(cb)
+    log.debug('React unavailable, pushing into onReactReady array')
+    ns.onReactReady = ns.onReactReady || []
+    ns.onReactReady.push(resolve)
+  })
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "create-react-class": "^15.5.3",
     "driftwood": "^1.1.6",
     "prop-types": "^15.5.10",
-    "slapdash": "^1.3.0"
+    "slapdash": "^1.3.0",
+    "sync-p": "^1.1.5"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/sandbox/experiment/experience2.js
+++ b/sandbox/experiment/experience2.js
@@ -1,33 +1,20 @@
 export function activation (options, cb) {
-  window.initiate = require('../../experience')
-  var experience = require('../../experience')(options.meta)
   window.opts = options
 
-  var release = experience.register([
-    'promo-banner-text'
-  ], function (slots, React) {
-    options.state.set('slots', slots)
-    options.state.set('React', React)
-    cb()
-  })
-
-  return {
-    remove: release
-  }
+  options.react.register(['promo-banner-text']).then(cb)
 }
 
 export function execution (options) {
-  var saleEnds = Date.now() + (10 * 60 * 1000)
+  var React = options.react.getReact()
 
-  var React = options.state.get('React')
-  var slots = options.state.get('slots')
+  var saleEnds = Date.now() + (10 * 60 * 1000)
 
   class Countdown extends React.Component {
     componentWillMount () {
       const { endDate } = this.props
-      this.state = {
+      this.setState({
         remaining: endDate - Date.now()
-      }
+      })
       this.interval = setInterval(() => {
         const remaining = endDate - Date.now()
         this.setState({ remaining: endDate - Date.now() })
@@ -49,11 +36,7 @@ export function execution (options) {
     }
   }
 
-  slots.render('promo-banner-text', function (props) {
+  options.react.render('promo-banner-text', function (props) {
     return <Countdown endDate={saleEnds} />
   })
-
-  return {
-    remove: slots.release
-  }
 }

--- a/sandbox/experiment/smartserve.js
+++ b/sandbox/experiment/smartserve.js
@@ -3,13 +3,14 @@ import * as experience2 from './experience2'
 
 import driftwood from 'driftwood'
 
-driftwood.enable({ '*': '*' }, { persist: true })
+driftwood.enable({ '*': 'debug' }, { persist: true })
 
 evaluateExperience('exp1', experience1)
 evaluateExperience('exp2', experience2)
 
 function evaluateExperience (name, experience) {
   const state = {}
+  const instance = require('../../experience')({ owner: name })
 
   const options = {
     meta: {
@@ -18,10 +19,23 @@ function evaluateExperience (name, experience) {
     state: {
       set: (key, value) => { state[key] = value },
       get: (key) => { return state[key] }
+    },
+    react: {
+      getReact: instance.getReact,
+      render: instance.render,
+      register: instance.register
     }
   }
 
-  experience.activation(options, () => {
-    experience.execution(options)
-  })
+  try {
+    experience.activation(options, () => {
+      try {
+        experience.execution(options)
+      } catch (e) {
+        console.error(e)
+      }
+    })
+  } catch (e) {
+    console.error(e)
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6942,6 +6942,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
+sync-p@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/sync-p/-/sync-p-1.1.5.tgz#fa3c2c31b8411e29cd8de339e6ff8a707c1f07a6"
+  integrity sha512-N+8VUzQIP8/d2boUkSihxy0Fp4+fMmwDKBryhEJbSuDSfYtSAUa1AKArO9tyHm8bUlyBOTd+XW8IwHWz1bWfrA==
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"


### PR DESCRIPTION
As well as being simpler to use, this resolves issues we have been having with multiple wrapper-based experiences trying to register for the same wrapper ID with different targeting criteria

In the previous world, ownership was taken as soon as you called `experience.register([], cb)` in the activation. Let's say we have two experiences, both rendering into the same slot. Experience A is targeting customers in London, experience B is targeting customers in New York. If the customer is in London, and Experience A's activation runs first, it will fire correctly. Experience B's activation will also run, but the qubit-react library will prevent it from registering and taking ownership. However, if Experience B activates first, it will take ownership, but won't end up firing because the user is not in New York. Experience A will then try and activate, but it won't be able to take ownership because Experience B already claimed it.

The solution to this problem is to move the ownership logic into the rendering stage. Now, when you call `register`, all we do is wait until the wrapper instance is available, and then fire the callback. When `render` is called in the experience execution, we check to see if the slot is free, and claim it. If its taken, we throw an error, which will get caught by experience-engine and emitted as an experience error event to be displayed in the experiences UI.

I have also implemented a tighter integration into experience-engine, which means that slot releasing is now automatic.

#### Old:

```js
function experienceActivation (options, cb) {
  const experience = require('qubit-react/experience')(options.meta)
  const release = experience.register(['header'], function (slots, React) {
    options.state.set('slots', slots)
    options.state.set('React', React)
  })
  return {
    remove: release
  }
}

function experienceExecution (options) {
  const React = options.state.get('React')
  const slots = options.state.get('slots')
  options.react.render('header', () => <div>New header!</div>)
  return {
    remove: slots.release
  }
}
```

#### New:

```js
function experienceActivation (options, cb) {
  options.react.register(['header']).then(cb)
}

function experienceExecution (options) {
  const React = options.react.getReact()
  options.react.render('header', () => <div>New header!</div>)
}
```

Note that this change is __backwards compatible__. You can still use the old syntax for now, meaning we can release this under a minor version bump.

### Todo

- [x] Fix broken tests
- [x] Add new tests for both old and new syntax
- [x] Add deprecation warning on old syntax
- [ ] Update docs.qubit.com, including migration guide and reasons
- [ ] Merge https://github.com/qubitdigital/experience-engine/pull/331