### PR TITLE
Support registering multiple slots in separate calls

### DIFF
--- a/__tests__/register-e2e-test.js
+++ b/__tests__/register-e2e-test.js
@@ -38,6 +38,47 @@ it('e2e - modern', async () => {
   expect(mounted.find('.anotherThing').length).toEqual(0)
 })
 
+it('e2e - multiple slots', async () => {
+  const React = require('react')
+  const QubitReactWrapper = require('../wrapper')
+  const mounted = mount(
+    <div>
+      <QubitReactWrapper id='wrapper1'>
+        <div className='wrapped' />
+      </QubitReactWrapper>
+      <QubitReactWrapper id='wrapper2'>
+        <div className='wrapped' />
+      </QubitReactWrapper>
+    </div>
+  )
+
+  const instance = experience({ owner: 'owner123' })
+  await instance.register(['wrapper1'])
+  expect(mounted.find('.wrapped').length).toEqual(2)
+  expect(mounted.find('.replaced').length).toEqual(0)
+
+  instance.render('wrapper1', () => <div className='replaced' />)
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(1)
+  expect(mounted.find('.replaced').length).toEqual(1)
+
+  await instance.register(['wrapper2'])
+  instance.render('wrapper2', () => <div className='replaced' />)
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(0)
+  expect(mounted.find('.replaced').length).toEqual(2)
+
+  instance.release('wrapper1')
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(1)
+  expect(mounted.find('.replaced').length).toEqual(1)
+
+  instance.release()
+  mounted.update()
+  expect(mounted.find('.wrapped').length).toEqual(2)
+  expect(mounted.find('.replaced').length).toEqual(0)
+})
+
 it('e2e - legacy', async () => {
   const React = require('react')
   const QubitReactWrapper = require('../wrapper')


### PR DESCRIPTION
A client has a use case where they have multiple slots on a page that _may_ render, but they don't know deterministically how many or which ones will show up. In a single experience, they want to target as many as possible, but our current registration API does not make this possible because we wait until _all_ the slots you register are available before resolving the callback or promise.

We can allow them to achieve what they want by supporting multiple calls to `register()`. This will allow them to create a registration per wrapper, and render all the slots individually as and when the registrations resolve.

The e2e test demonstrates this in action - we are able to register and release slots one-by-one.

